### PR TITLE
Add historical backfill and CLI trigger

### DIFF
--- a/snb_prometheus/backfill.py
+++ b/snb_prometheus/backfill.py
@@ -1,0 +1,94 @@
+"""Utilities for importing historical SNB data into Prometheus."""
+
+from __future__ import annotations
+
+import csv
+import subprocess
+import tempfile
+from datetime import datetime
+from typing import List, Tuple
+
+from .config import Config, CONFIG
+from .fetcher import fetch_csv
+
+
+# Prometheus metric name used throughout the project
+_METRIC_NAME = "snb_indicator_value"
+
+
+def _parse_series(csv_text: str) -> List[Tuple[int, float]]:
+    """Parse a full CSV download into ``(timestamp, value)`` pairs.
+
+    The SNB CSV format contains a metadata header separated from the data by a
+    blank line and uses semicolons as field delimiters. Each data row contains a
+    ``Date`` column and a ``Value`` column. The returned timestamps are Unix
+    epoch seconds suitable for Prometheus.
+    """
+
+    lines = csv_text.splitlines()
+    try:
+        empty_idx = next(i for i, line in enumerate(lines) if not line.strip())
+        data_lines = lines[empty_idx + 1 :]
+    except StopIteration:
+        data_lines = lines
+
+    reader = csv.DictReader(data_lines, delimiter=";")
+    series: List[Tuple[int, float]] = []
+    for row in reader:
+        date = row.get("Date") or row.get("DATE")
+        value = row.get("Value") or row.get("VALUE")
+        if date is None or value is None:
+            continue
+        timestamp = int(datetime.fromisoformat(date).timestamp())
+        series.append((timestamp, float(value)))
+    return series
+
+
+def _build_openmetrics(config: Config) -> str:
+    """Return OpenMetrics text for all indicators in *config*."""
+
+    lines: List[str] = [f"# TYPE {_METRIC_NAME} gauge\n"]
+    for indicator, (cube, keyseries) in config.indicators.items():
+        csv_text = fetch_csv(cube, params={"filter[KEYSERIES]": keyseries})
+        for ts, value in _parse_series(csv_text):
+            lines.append(
+                f"{_METRIC_NAME}{{indicator=\"{indicator}\"}} {value} {ts}\n"
+            )
+    return "".join(lines)
+
+
+def backfill(
+    config: Config = CONFIG,
+    *,
+    promtool_path: str = "promtool",
+    tsdb_path: str = ".",
+) -> None:
+    """Fetch historical data and load it into Prometheus via ``promtool``.
+
+    Parameters
+    ----------
+    config:
+        Configuration describing which indicators to import.
+    promtool_path:
+        Path to the ``promtool`` binary.
+    tsdb_path:
+        Destination directory for the created TSDB blocks. This should point to
+        Prometheus' data directory.
+    """
+
+    metrics_text = _build_openmetrics(config)
+    with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+        tmp.write(metrics_text)
+        tmp_path = tmp.name
+
+    subprocess.run(
+        [
+            promtool_path,
+            "tsdb",
+            "create-blocks-from",
+            "openmetrics",
+            tmp_path,
+            tsdb_path,
+        ],
+        check=True,
+    )

--- a/snb_prometheus/main.py
+++ b/snb_prometheus/main.py
@@ -1,7 +1,26 @@
 """CLI entry point for SNB Prometheus service."""
 
+from __future__ import annotations
+
+import argparse
+
+from .backfill import backfill
 from .server import run_server
 
 
-if __name__ == "__main__":
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help="Fetch historical data and load it into Prometheus before starting the server",
+    )
+    args = parser.parse_args()
+
+    if args.backfill:
+        backfill()
     run_server()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,61 @@
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from snb_prometheus.backfill import backfill
+from snb_prometheus.config import Config
+
+
+def test_backfill_invokes_promtool(monkeypatch, tmp_path):
+    csv_text = Path("tests/data/sample_indicator.csv").read_text()
+
+    def fake_fetch_csv(cube, language="en", params=None):
+        assert cube == "monzano"
+        assert params == {"filter[KEYSERIES]": "A.POLIRATE"}
+        return csv_text
+
+    monkeypatch.setattr("snb_prometheus.backfill.fetch_csv", fake_fetch_csv)
+
+    recorded = {}
+
+    def fake_run(cmd, check):
+        recorded["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    cfg = Config(indicators={"policy_rate": ("monzano", "A.POLIRATE")})
+    backfill(cfg, tsdb_path=str(tmp_path))
+
+    cmd = recorded["cmd"]
+    assert cmd[:4] == ["promtool", "tsdb", "create-blocks-from", "openmetrics"]
+    metrics_file = Path(cmd[4])
+    content = metrics_file.read_text().splitlines()
+    assert content[0] == "# TYPE snb_indicator_value gauge"
+    ts1 = int(datetime.fromisoformat("2023-01-01").timestamp())
+    ts2 = int(datetime.fromisoformat("2023-02-01").timestamp())
+    assert (
+        content[1]
+        == f'snb_indicator_value{{indicator="policy_rate"}} 1.0 {ts1}'
+    )
+    assert (
+        content[2]
+        == f'snb_indicator_value{{indicator="policy_rate"}} 1.5 {ts2}'
+    )
+
+
+def test_main_backfill(monkeypatch):
+    calls = []
+    monkeypatch.setattr("snb_prometheus.main.run_server", lambda: calls.append("server"))
+    monkeypatch.setattr("snb_prometheus.main.backfill", lambda: calls.append("backfill"))
+
+    import sys
+
+    monkeypatch.setattr(sys, "argv", ["prog", "--backfill"])
+    from snb_prometheus import main as main_mod
+
+    main_mod.main()
+    assert calls == ["backfill", "server"]

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,4 +1,7 @@
 import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from snb_prometheus.fetcher import parse_latest
 


### PR DESCRIPTION
## Summary
- add `backfill` module to fetch historical indicator data and ingest into Prometheus via `promtool`
- extend CLI with `--backfill` flag to run the backfill before starting the server
- cover backfill logic with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f402a5188322be0aceff6a7d11a1