### PR TITLE
Use SNB datasets for interest and inflation

### DIFF
--- a/grafana/interest_inflation_dashboard.json
+++ b/grafana/interest_inflation_dashboard.json
@@ -1,0 +1,41 @@
+{
+  "title": "Interest Rates and Inflation",
+  "uid": "interest-inflation-demo",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {"from": "now-5y", "to": "now"},
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Interest Rates",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "percent"}},
+      "targets": [
+        {
+          "expr": "snb_indicator_value{indicator=\"switzerland_interest_rate\"}",
+          "legendFormat": "Switzerland"
+        },
+        {
+          "expr": "snb_indicator_value{indicator=\"uk_interest_rate\"}",
+          "legendFormat": "United Kingdom"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Inflation",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "percent"}},
+      "targets": [
+        {
+          "expr": "snb_indicator_value{indicator=\"switzerland_inflation\"}",
+          "legendFormat": "Switzerland"
+        },
+        {
+          "expr": "snb_indicator_value{indicator=\"uk_inflation\"}",
+          "legendFormat": "United Kingdom"
+        }
+      ]
+    }
+  ]
+}

--- a/snb_prometheus/config.py
+++ b/snb_prometheus/config.py
@@ -8,11 +8,26 @@ class Config:
 
     port: int = 8000
     update_interval: int = 24 * 60 * 60  # seconds
+    # Each indicator is defined as a tuple ``(cube, keyseries)`` where ``cube``
+    # is the SNB table identifier and ``keyseries`` selects the desired
+    # timeseries within that cube.
     indicators: Dict[str, Tuple[str, str]] = field(
         default_factory=lambda: {
-            "policy_rate": ("monzano", "A.POLIRATE")
+            "policy_rate": ("snboffzisa", "LZ"),
         }
     )
 
 
 CONFIG = Config()
+
+# Configuration covering interest rate and inflation data for Switzerland and
+# the United Kingdom using SNB datasets.  This configuration can be passed to
+# the server/backfill helpers to expose the additional metrics.
+INTEREST_INFLATION_CONFIG = Config(
+    indicators={
+        "switzerland_interest_rate": ("snboffzisa", "LZ"),
+        "uk_interest_rate": ("snboffzisa", "L0"),
+        "switzerland_inflation": ("iukpaus", "S"),
+        "uk_inflation": ("iukpaus", "VK"),
+    }
+)

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -13,8 +13,8 @@ def test_backfill_invokes_promtool(monkeypatch, tmp_path):
     csv_text = Path("tests/data/sample_indicator.csv").read_text()
 
     def fake_fetch_csv(cube, language="en", params=None):
-        assert cube == "monzano"
-        assert params == {"filter[KEYSERIES]": "A.POLIRATE"}
+        assert cube == "snboffzisa"
+        assert params == {"dimSel": "D0(LZ)"}
         return csv_text
 
     monkeypatch.setattr("snb_prometheus.backfill.fetch_csv", fake_fetch_csv)
@@ -27,7 +27,7 @@ def test_backfill_invokes_promtool(monkeypatch, tmp_path):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    cfg = Config(indicators={"policy_rate": ("monzano", "A.POLIRATE")})
+    cfg = Config(indicators={"policy_rate": ("snboffzisa", "LZ")})
     backfill(cfg, tsdb_path=str(tmp_path))
 
     cmd = recorded["cmd"]


### PR DESCRIPTION
## Summary
- remove World Bank provider and rely solely on SNB API
- add configuration for Swiss and UK interest rates and inflation using SNB cubes
- retain sample Grafana dashboard visualizing the four indicators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f5b05240832293ce9961fae8341e